### PR TITLE
Added startbutton packaging script

### DIFF
--- a/packaging/deb/start/README.md
+++ b/packaging/deb/start/README.md
@@ -1,0 +1,11 @@
+### Installing the Windows XP start button
+
+Run the start button installer.
+` sudo start-button.sh `
+
+If you are missing dependencies, install them and run the command again.
+The start button installer script requires `fakeroot`, `cmake`, `libgarcon-gtk3-1-dev`, and `libxfce4panel-2.0-4`.
+
+The script should compile the start button source and copy over all the project's related files to where they need to go for XFCE to recognize the plugin.
+
+If you have any questions or problems please open an issue.

--- a/packaging/deb/start/start-button.sh
+++ b/packaging/deb/start/start-button.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+START_DIR="${PWD}/../../../shell/start"
+BUILD_DIR="${START_DIR}/build"
+WINXP_DIR="/usr/share/winxp"
+REQUIRED_PACKAGES=( 'fakeroot' 'cmake' 'libgarcon-gtk3-1-dev' 'libxfce4panel-2.0-4' )
+
+# Check for dependencies
+
+echo "Checking for dependencies..."
+
+for package in "${REQUIRED_PACKAGES[@]}"
+do
+	dpkg -s $package > /dev/null 2>&1
+
+	if [[ $? -gt 0 ]]
+	then
+		echo "You are missing package: ${package}"
+		exit 1
+	fi
+done
+
+
+# Create winxp dir if it doesn't already exist
+if [ ! -e $WINXP_DIR ]
+then
+	mkdir $WINXP_DIR
+	mkdir -p "{$WINXP_DIR}/shell-res"
+	echo "Directory ${WINXP_DIR} created."
+else
+	echo "Directory ${WINXP_DIR} exists."
+fi
+
+# Copy over necessary files
+fakeroot cp -r "${START_DIR}/startbutton.desktop" "/usr/share/xfce4/panel/plugins/startbutton.desktop"
+fakeroot cp -r "${START_DIR}/res/." "${WINXP_DIR}/shell-res/"
+
+echo "Files copied."
+
+# Compile start menu using cmake
+echo "Compiling project..."
+
+if [ ! -d $BUILD_DIR ]
+then
+	mkdir $BUILD_DIR
+else
+	echo "${BUILD_DIR} directory already exists."
+fi
+
+cd $BUILD_DIR
+cmake ..
+make
+
+if [ -e "libstartbutton-plugin.so" ]
+then
+	fakeroot cp -r "libstartbutton-plugin.so" "/usr/lib/x86_64-linux-gnu/xfce4/panel/plugins/libstartbutton-plugin.so"
+else
+	echo "libstartbutton-plugin.so not found."
+fi
+
+echo "Done."
+


### PR DESCRIPTION
Adds a script to more easily copy over the necessary files to where they need to go for the plugin to work, and compile the start button project. You should just have to run the script and add the start button item to your panel from an uncompiled start button. Also added a README for instructions.