### PR TITLE
Dockerfile for easy compilation and packaging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM debian:11
+
+RUN apt update && apt install build-essential git cmake fakeroot gettext pkg-config libglib2.0-dev libgtk-3-dev libgarcon-1-dev libgarcon-gtk3-1-dev libxfce4panel-2.0-dev -y
+
+# Standalone build with git clone inside the container
+# RUN git clone https://github.com/rozniak/xfce-winxp-tc.git --recurse-submodules /xfce-winxp-tc
+
+# Relative build with files from local repository
+ADD . /xfce-winxp-tc
+
+# To print logs while build uncomment next line and use `docker build --progress=plain . -t xfce-winxp-tc`
+# RUN sed -i 's/>\+ "${log_path}" 2>&1//g' $(find /xfce-winxp-tc/packaging/deb -iname '*.sh')
+
+WORKDIR /deb
+
+RUN /xfce-winxp-tc/packaging/deb/libs/packlibs.sh comgtk && dpkg -i libcomgtk.deb
+RUN /xfce-winxp-tc/packaging/deb/libs/packlibs.sh exec && dpkg -i libexec.deb
+RUN /xfce-winxp-tc/packaging/deb/libs/packlibs.sh shllang && dpkg -i libshllang.deb
+
+ENV PKG_CONFIG_PATH='/lib/x86_64-linux-gnu/pkgconfig'
+
+RUN /xfce-winxp-tc/packaging/deb/panel/packplug.sh shell/start shell/systray
+RUN /xfce-winxp-tc/packaging/deb/programs/packprog.sh shell/run shell/winver
+RUN /xfce-winxp-tc/packaging/deb/cursors/packcurs.sh no-shadow/standard shadow/standard
+RUN /xfce-winxp-tc/packaging/deb/icons/packicon.sh luna
+RUN /xfce-winxp-tc/packaging/deb/fonts/packfnts.sh
+RUN /xfce-winxp-tc/packaging/deb/sounds/packsnds.sh
+RUN /xfce-winxp-tc/packaging/deb/themes/packthem.sh
+
+VOLUME /deb

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Instructions:
 # 1. Build image: `docker build -t xfce-winxp-tc .`
 # 2. Run container: `docker run --rm -v ./out:/out xfce-winxp-tc`
-# 3. Package files will be copied `./out` directory
-# 4. For Arch Linux use `debtap` to install packages
+# 3. Package files will be copied to `./out` directory
+# 4. For Arch Linux use `debtap` to convert packages to `pacman` format
 
 FROM debian:11
 
@@ -42,6 +42,7 @@ RUN /xfce-winxp-tc/packaging/deb/libs/packlibs.sh shllang && dpkg -i libshllang.
 # Variable needed by dpkg to see installed packages
 ENV PKG_CONFIG_PATH='/lib/x86_64-linux-gnu/pkgconfig'
 
+# Compile and package all final components (comment out unnecessary components)
 RUN /xfce-winxp-tc/packaging/deb/panel/packplug.sh shell/start shell/systray
 RUN /xfce-winxp-tc/packaging/deb/programs/packprog.sh shell/run shell/winver
 RUN /xfce-winxp-tc/packaging/deb/cursors/packcurs.sh no-shadow/standard with-shadow/standard

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,58 @@
+# Instructions:
+# 1. Build image: `docker build -t xfce-winxp-tc .`
+# 2. Run container: `docker run --rm -v ./out:/out xfce-winxp-tc`
+# 3. Package files will be copied `./out` directory
+# 4. For Arch Linux use `debtap` to install packages
+
 FROM debian:11
 
-RUN apt update && apt install build-essential git cmake fakeroot gettext pkg-config libglib2.0-dev libgtk-3-dev libgarcon-1-dev libgarcon-gtk3-1-dev libxfce4panel-2.0-dev -y
+RUN apt update && apt install -y \
+	build-essential \
+	git \
+	cmake \
+	fakeroot \
+	gettext \
+	pkg-config \
+	libglib2.0-dev \
+	libgtk-3-dev \
+	libgarcon-1-dev \
+	libgarcon-gtk3-1-dev \
+	libxfce4panel-2.0-dev \
+	rename x11-apps \
+	ruby-sass \
+	python3-venv
 
-# Standalone build with git clone inside the container
+# Standalone build with git clone inside the container (instead of 'ADD')
 # RUN git clone https://github.com/rozniak/xfce-winxp-tc.git --recurse-submodules /xfce-winxp-tc
 
-# Relative build with files from local repository
+# Relative build with files from local repository (instead of 'RUN git clone')
 ADD . /xfce-winxp-tc
 
-# To print logs while build uncomment next line and use `docker build --progress=plain . -t xfce-winxp-tc`
+# Optionally log all messages to STDOUT for easy debugging
 # RUN sed -i 's/>\+ "${log_path}" 2>&1//g' $(find /xfce-winxp-tc/packaging/deb -iname '*.sh')
+# RUN sed -i 's/>\+ "${CMAKE_LOG_PATH}"//g' $(find /xfce-winxp-tc/packaging/deb -iname '*.sh')
 
 WORKDIR /deb
 
+# Compile and install included libraries used as dependencies for final components
 RUN /xfce-winxp-tc/packaging/deb/libs/packlibs.sh comgtk && dpkg -i libcomgtk.deb
 RUN /xfce-winxp-tc/packaging/deb/libs/packlibs.sh exec && dpkg -i libexec.deb
 RUN /xfce-winxp-tc/packaging/deb/libs/packlibs.sh shllang && dpkg -i libshllang.deb
 
+# Variable needed by dpkg to see installed packages
 ENV PKG_CONFIG_PATH='/lib/x86_64-linux-gnu/pkgconfig'
 
 RUN /xfce-winxp-tc/packaging/deb/panel/packplug.sh shell/start shell/systray
 RUN /xfce-winxp-tc/packaging/deb/programs/packprog.sh shell/run shell/winver
-RUN /xfce-winxp-tc/packaging/deb/cursors/packcurs.sh no-shadow/standard shadow/standard
+RUN /xfce-winxp-tc/packaging/deb/cursors/packcurs.sh no-shadow/standard with-shadow/standard
 RUN /xfce-winxp-tc/packaging/deb/icons/packicon.sh luna
 RUN /xfce-winxp-tc/packaging/deb/fonts/packfnts.sh
 RUN /xfce-winxp-tc/packaging/deb/sounds/packsnds.sh
-RUN /xfce-winxp-tc/packaging/deb/themes/packthem.sh
 
-VOLUME /deb
+# Fix for unexpected character (SCSS compilation)
+RUN sed -i "s/’/'/g" $(find /xfce-winxp-tc/themes -iname '*.scss')
+RUN /xfce-winxp-tc/packaging/deb/themes/packthem.sh luna/blue native professional
+
+# Copy all packages and logs to `/out` mounted directory
+VOLUME /out
+CMD cp /deb/* /out


### PR DESCRIPTION
After many trials and errors I've managed to create working Docker build definition for compiling and creating `.deb` packages. I personally use Arch Linux on all my machines so additional use of Debian didn't look inviting. This Dockerfile can be use with files from repository for easy development or as standalone pipeline for automated CI/CD. Everything is described inside.

I'm not a Docker guru so surely this script can be improved but for now I think it's good enough until #35 will be resolved.