### PR TITLE
Fix failed build because of invalid character in a comment

### DIFF
--- a/themes/build-common/gtk-3.0-base/common/pathbar.scss
+++ b/themes/build-common/gtk-3.0-base/common/pathbar.scss
@@ -9,7 +9,7 @@
 
 //
 // GtkPathBar does not work with just .linked, so we must override that. But we
-// can’t simply remove .linked from the widget as that might break other themes.
+// can't simply remove .linked from the widget as that might break other themes.
 //
 // Note also we select on filechooser to avoid interfering with NautilusPathBar.
 //


### PR DESCRIPTION
The compiler doesn't like non-ASCII characters.