### PR TITLE
Fix missing lib for components build (winver & notepad)

### DIFF
--- a/shell/winver/CMakeLists.txt
+++ b/shell/winver/CMakeLists.txt
@@ -26,6 +26,7 @@ wintc_resolve_library(wintc-comctl   WINTC_COMCTL)
 wintc_resolve_library(wintc-comgtk   WINTC_COMGTK)
 wintc_resolve_library(wintc-shell    WINTC_SHELL)
 wintc_resolve_library(wintc-winbrand WINTC_WINBRAND)
+wintc_resolve_library(wintc-shellext WINTC_SHELLEXT)
 
 add_executable(
     wintc-winver
@@ -56,6 +57,7 @@ target_include_directories(
     PRIVATE ${WINTC_COMGTK_INCLUDE_DIRS}
     PRIVATE ${WINTC_SHELL_INCLUDE_DIRS}
     PRIVATE ${WINTC_WINBRAND_INCLUDE_DIRS}
+    PRIVATE ${WINTC_SHELLEXT_INCLUDE_DIRS}
 )
 
 target_link_directories(
@@ -67,6 +69,7 @@ target_link_directories(
     PRIVATE ${WINTC_COMGTK_LIBRARY_DIRS}
     PRIVATE ${WINTC_SHELL_LIBRARY_DIRS}
     PRIVATE ${WINTC_WINBRAND_LIBRARY_DIRS}
+    PRIVATE ${WINTC_SHELLEXT_LIBRARY_DIRS}
 )
 
 target_link_libraries(
@@ -78,6 +81,7 @@ target_link_libraries(
     PRIVATE ${WINTC_COMGTK_LIBRARIES}
     PRIVATE ${WINTC_SHELL_LIBRARIES}
     PRIVATE ${WINTC_WINBRAND_LIBRARIES}
+    PRIVATE ${WINTC_SHELLEXT_LIBRARIES}
 )
 
 # FreeBSD requires linking to libsysinfo port

--- a/shell/winver/deps
+++ b/shell/winver/deps
@@ -5,3 +5,4 @@ bt,rt:sysinfo
 bt,rt:wintc-comctl
 bt,rt:wintc-comgtk
 bt,rt:wintc-winbrand
+bt,rt:wintc-shellext

--- a/windows/notepad/CMakeLists.txt
+++ b/windows/notepad/CMakeLists.txt
@@ -27,6 +27,7 @@ wintc_resolve_library(wintc-comgtk   WINTC_COMGTK)
 wintc_resolve_library(wintc-shcommon WINTC_SHCOMMON)
 wintc_resolve_library(wintc-shell    WINTC_SHELL)
 wintc_resolve_library(wintc-shlang   WINTC_SHLANG)
+wintc_resolve_library(wintc-shellext WINTC_SHELLEXT)
 
 wintc_compile_resources()
 wintc_create_meta_h()
@@ -78,6 +79,7 @@ target_include_directories(
     PRIVATE ${WINTC_SHCOMMON_INCLUDE_DIRS}
     PRIVATE ${WINTC_SHELL_INCLUDE_DIRS}
     PRIVATE ${WINTC_SHLANG_INCLUDE_DIRS}
+    PRIVATE ${WINTC_SHELLEXT_INCLUDE_DIRS}
 )
 
 target_link_directories(
@@ -88,6 +90,7 @@ target_link_directories(
     PRIVATE ${WINTC_SHCOMMON_LIBRARY_DIRS}
     PRIVATE ${WINTC_SHELL_LIBRARY_DIRS}
     PRIVATE ${WINTC_SHLANG_LIBRARY_DIRS}
+    PRIVATE ${WINTC_SHELLEXT_LIBRARY_DIRS}
 )
 
 target_link_libraries(
@@ -98,6 +101,7 @@ target_link_libraries(
     PRIVATE ${WINTC_SHCOMMON_LIBRARIES}
     PRIVATE ${WINTC_SHELL_LIBRARIES}
     PRIVATE ${WINTC_SHLANG_LIBRARIES}
+    PRIVATE ${WINTC_SHELLEXT_LIBRARIES}
 )
 
 add_dependencies(

--- a/windows/notepad/deps
+++ b/windows/notepad/deps
@@ -3,3 +3,4 @@ bt,rt:gtk3
 bt,rt:wintc-comgtk
 bt,rt:wintc-shcommon
 bt,rt:wintc-shlang
+bt,rt:wintc-shellext


### PR DESCRIPTION
They were missing `shellext.h` during build and failing.