### PR TITLE
Fix some missing/wrong strings for Japanese locale, fix "Connect To" item having unnecessary ellipsis

### DIFF
--- a/shared/shlang/po/ja_JP.po
+++ b/shared/shlang/po/ja_JP.po
@@ -230,16 +230,16 @@ msgid "Favorites"
 msgstr "お気に入り(A)"
 
 msgid "My Documents"
-msgstr "My Documents"
+msgstr "マイ ドキュメント"
 
 msgid "My Music"
-msgstr "My Music"
+msgstr "マイ ミュージック"
 
 msgid "My Pictures"
-msgstr "My Pictures"
+msgstr "マイ ピクチャ"
 
 msgid "My Recent Documents"
-msgstr "最近使ったファイル"
+msgstr "最近使ったファイル(D)"
 
 msgid "Recycle Bin"
 msgstr "ごみ箱"
@@ -258,7 +258,7 @@ msgid "My Network Places"
 msgstr "マイ ネットワーク"
 
 msgid "Control Panel"
-msgstr "コントロール パネル"
+msgstr "コントロール パネル(C)"
 
 msgid "Network Connections"
 msgstr "ネットワーク接続"

--- a/shell/taskband/po/ja_JP.po
+++ b/shell/taskband/po/ja_JP.po
@@ -49,7 +49,7 @@ msgstr ""
 "ユーザーに切り替えるオプションを提供します。"
 
 msgid "Turn Off Computer"
-msgstr "コンピュータの終了"
+msgstr "終了オプション(U)"
 
 msgid ""
 "Provides options for turning off or restarting your computer, or for "
@@ -128,7 +128,7 @@ msgstr ""
 "どを集中して参照できる場所を開きます。"
 
 msgid "Help and Support"
-msgstr "ヘルプとサポート"
+msgstr "ヘルプとサポート(H)"
 
 msgid ""
 "Opens a window where you can pick search options and work with search "

--- a/shell/taskband/src/res/personal-menu.ui
+++ b/shell/taskband/src/res/personal-menu.ui
@@ -518,7 +518,7 @@
                           <object class="GtkLabel">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
-                            <property name="label" translatable="yes">Connect To...</property>
+                            <property name="label" translatable="yes">Connect To</property>
                             <property name="max-width-chars">24</property>
                             <property name="tooltip-text" translatable="yes">Connects to other computers, networks, and the Internet.</property>
                             <property name="wrap">True</property>


### PR DESCRIPTION
Also, I changed the "Turn Off Computer" string to "終了オプション(U)" which seems to be correct in Windows XP SP3 (I'm not sure if this is the only release in Japanese), let me know if this is wrong

Screenshot from my SP3 VM:

![image](https://github.com/user-attachments/assets/aca66446-b9a1-47d1-bbc2-f17525245f81)


Another reference screenshot: (Not sure which version but probably SP3 if other service packs didn't release in Japanese)

![image](https://github.com/user-attachments/assets/d0318e8a-398c-466b-96e5-2a3421b93151)



