### PR TITLE
Enhancement: Adds "enter" key shortcut for the logon UI #467

### DIFF
--- a/base/logonui/src/welcome/userlist.c
+++ b/base/logonui/src/welcome/userlist.c
@@ -377,6 +377,13 @@ static void wintc_welcome_user_list_init(
         G_CALLBACK(on_button_go_clicked),
         self
     );
+    
+    g_signal_connect(
+        self->entry_password,
+        "activate",
+        G_CALLBACK(on_button_go_clicked),
+        self
+);
 
     // Add style classes
     //


### PR DESCRIPTION
Simple tweak for the wintc-logonui component that allows a user to log in using the enter key instead of having to click the go button.
![Peek 2025-05-02 14-53](https://github.com/user-attachments/assets/e2be57a6-8340-4247-8b82-607d30eb4d5d)
