### PR TITLE
Make start menu and logonui use full usernames instead of the short ones

### DIFF
--- a/base/logonui/src/welcome/userlist.c
+++ b/base/logonui/src/welcome/userlist.c
@@ -183,6 +183,13 @@ static void on_realize_enable_passthrough(
     gpointer   user_data
 );
 
+static const gchar* get_display_name(UserListItem* item)
+{
+    if (item->real_name && item->real_name[0] != '\0')
+        return item->real_name;
+    return item->name ? item->name : "";
+}
+
 //
 // GTK OOP CLASS/INSTANCE DEFINITIONS
 //
@@ -605,7 +612,7 @@ static GtkWidget* build_userlist_widget(
         );
         gtk_label_set_text(
             GTK_LABEL(item->username_label),
-            item->real_name
+            get_display_name(item)
         );
 
         g_object_unref(profile_image);

--- a/base/logonui/src/welcome/userlist.c
+++ b/base/logonui/src/welcome/userlist.c
@@ -28,6 +28,7 @@ typedef struct _UserListItem
     WinTCWelcomeUserList* parent; 
 
     gchar*       name;
+    gchar*  real_name;
     LightDMUser* user;
 
     // UI state
@@ -525,6 +526,7 @@ static GtkWidget* build_userlist_widget(
 
         item->user     = (LightDMUser*) l->data; 
         item->name     = g_strdup(lightdm_user_get_name(item->user));
+        item->real_name = g_strdup(lightdm_user_get_real_name(item->user));
         item->parent   = user_list; 
         item->faded    = FALSE;
 
@@ -603,7 +605,7 @@ static GtkWidget* build_userlist_widget(
         );
         gtk_label_set_text(
             GTK_LABEL(item->username_label),
-            item->name
+            item->real_name
         );
 
         g_object_unref(profile_image);

--- a/shell/taskband/src/start/personal.c
+++ b/shell/taskband/src/start/personal.c
@@ -225,11 +225,11 @@ void create_personal_menu(
 
     gtk_label_set_text(
         GTK_LABEL(gtk_builder_get_object(builder, "label-username-horz")),
-        user_pwd->pw_name
+        user_pwd->pw_gecos
     );
     gtk_label_set_text(
         GTK_LABEL(gtk_builder_get_object(builder, "label-username-vert")),
-        user_pwd->pw_name
+        user_pwd->pw_gecos
     );
 
     // Attach Recent Documents submenu

--- a/shell/taskband/src/start/personal.c
+++ b/shell/taskband/src/start/personal.c
@@ -223,14 +223,25 @@ void create_personal_menu(
     //
     struct passwd* user_pwd = getpwuid(getuid());
 
+    const gchar* real_name = NULL;
+    const gchar* short_name = NULL;
+
+    real_name = user_pwd ? user_pwd->pw_gecos : NULL;
+    short_name = user_pwd ? user_pwd->pw_name  : NULL;
+
+    const gchar* display_name = (real_name && real_name[0] != '\0') ? real_name : short_name;
+
     gtk_label_set_text(
         GTK_LABEL(gtk_builder_get_object(builder, "label-username-horz")),
-        user_pwd->pw_gecos
+        display_name ? display_name : ""
     );
+
     gtk_label_set_text(
         GTK_LABEL(gtk_builder_get_object(builder, "label-username-vert")),
-        user_pwd->pw_gecos
+        display_name ? display_name : ""
     );
+
+
 
     // Attach Recent Documents submenu
     //


### PR DESCRIPTION
I noticed that start menu and logonui use short usernames and not the full ones. Now it uses the full ones like XP does.
Before:
<img width="341" height="497" alt="pre" src="https://github.com/user-attachments/assets/c3a71338-7007-40c6-bb42-53b7ef6b0345" />
After:
<img width="387" height="497" alt="post" src="https://github.com/user-attachments/assets/8c2faba8-a4f5-44d0-98dc-68ae8dbf52a6" />
logonui:
<img width="729" height="420" alt="logonui" src="https://github.com/user-attachments/assets/31e6a5d8-6a99-400d-a616-049e00874a01" />

Tested on Arch (VM) and on Cachy OS (My main PC). It has fallbacks incase there is only  a short name available.